### PR TITLE
Statistics Page

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,10 +9,6 @@ const less = require('less-middleware');
 const jsx = require('express-react-views');
 const path = require('path');
 
-// Routers
-const indexRouter = require('./app/routes/index');
-const statsRouter = require('./app/routes/stats');
-
 // Config
 app.use(bodyParser.json()); // Parse POST Requests
 app.use(bodyParser.urlencoded({ extended: true }));
@@ -22,10 +18,9 @@ app.set('views', path.join(__dirname, 'app/views')); // Views
 app.set('view engine', 'jsx'); // View Engine
 app.engine('jsx', jsx.createEngine());
 
-// Routes
-app.use('/', indexRouter);
-// app.post('/', indexRouter);
-app.get('/stats', statsRouter);
+// Routes/Controllers
+app.use('/'     , require('./app/routes/index'));
+app.get('/stats', require('./app/routes/stats'));
 
 // Launch Server
 app.listen(port, () => console.log(`Server listening on port ${port}.\nConnect via http://localhost:${port}`));

--- a/app/public/stylesheets/style.less
+++ b/app/public/stylesheets/style.less
@@ -166,3 +166,14 @@ label[for="question"] {
 .h-question {
   .montserrat-semibold;
 }
+
+// Statistics
+.stats {
+  width: 700px;
+  margin: 0 auto;
+  text-align: center;
+
+  img {
+    display: block;
+  }
+}

--- a/app/routes/stats.js
+++ b/app/routes/stats.js
@@ -1,6 +1,6 @@
 const router = require('express').Router();
 
 // GET Statistics
-router.get('/stats', (req, res) => res.render('stats', { appName: "Magic 8-Ball" }));
+router.get('/stats', (req, res) => res.render('stats'));
 
 module.exports = router;

--- a/app/routes/stats.js
+++ b/app/routes/stats.js
@@ -1,6 +1,26 @@
 const router = require('express').Router();
+const Sequelise = require('sequelize');
+const db = new Sequelise('sqlite:./app/db/history.db');
 
 // GET Statistics
-router.get('/stats', (req, res) => res.render('stats'));
+router.get('/stats', (req, res) => {
+  const questionsSql = `
+    SELECT COUNT(*) AS Count, SUBSTR(createdAt, 1, 10) AS Date
+    FROM Questions
+    GROUP BY Date
+  `;
+  db.query(questionsSql).then(questions => {
+    const ratiosSql = `
+      SELECT COUNT(*) AS Count, AnswerTypes.name AS AnswerType
+      FROM Questions
+      INNER JOIN Answers ON Questions.answerId = Answers.id
+      INNER JOIN AnswerTypes ON Answers.answerTypeId = AnswerTypes.id
+      GROUP BY AnswerTypes.name
+    `;
+    db.query(ratiosSql).then(ratios => {
+      res.render('stats', { questions: questions[0], ratios: ratios[0] });
+    });
+  });
+});
 
 module.exports = router;

--- a/app/views/stats.jsx
+++ b/app/views/stats.jsx
@@ -5,14 +5,27 @@ const Plotly = require('plotly')('ChrisMB', 'Y2HHjdER1NU2chHcNjBb');
 // Statistics Page
 class StatsPage extends React.Component
 {
-  updateQuestionsGraph()
+  get questionsData()
   {
-    const data = [{
-      x: [ '2019-10-04T12:56:53.761Z', '2019-11-04T12:56:53.761Z', '2019-12-04T12:56:53.761Z' ],
-      y: [ 1, 3, 6 ],
+    const questions = [];
+    const dates = [];
+
+    this.props.questions.forEach(question => {
+      questions.push(question.Count);
+      dates.push(question.Date);
+    });
+
+    return {
+      x: dates,
+      y: questions,
       type: 'scatter',
       line: { color: 'white' }
-    }];
+    };
+  }
+
+  updateQuestionsGraph()
+  {
+    const data = [this.questionsData];
 
     const axisStyle = {
       autorange: true,
@@ -50,14 +63,27 @@ class StatsPage extends React.Component
     console.log('Plotly: loaded questions graph');
   }
 
+  get ratiosData()
+  {
+    const answerTypes = [];
+    const amounts = [];
+
+    this.props.ratios.forEach(ratio => {
+      answerTypes.push(ratio.AnswerType);
+      amounts.push(ratio.Count);
+    });
+
+    return {
+      labels: answerTypes,
+      values: amounts,
+      marker: { colors: [ '#63DA62', '#D9DA62', '#DA4D4D' ] },
+      type: 'pie'
+    };
+  }
+
   updateRatiosGraph()
   {
-    const data = [{
-      labels: [ 'affirmative', 'non-committal', 'negative' ],
-      values: [ 6, 7, 4 ],
-      marker: { colors: [ '#63DA62', '#D9DA62', '#DA4D4D' ] },
-      type: 'pie',
-    }];
+    const data = [this.ratiosData];
 
     const layout = {
       autosize: false,

--- a/app/views/stats.jsx
+++ b/app/views/stats.jsx
@@ -1,15 +1,136 @@
 const React = require('react');
 const PageLayout = require('./layout');
+const Plotly = require('plotly')('ChrisMB', 'Y2HHjdER1NU2chHcNjBb');
 
 // Statistics Page
 class StatsPage extends React.Component
 {
+  updateQuestionsGraph()
+  {
+    const data = [{
+      x: [ '2019-10-04T12:56:53.761Z', '2019-11-04T12:56:53.761Z', '2019-12-04T12:56:53.761Z' ],
+      y: [ 1, 3, 6 ],
+      type: 'scatter',
+      line: { color: 'white' }
+    }];
+
+    const axisStyle = {
+      autorange: true,
+      showgrid: false,
+      zeroline: false,
+      showline: true,
+      autotick: true,
+      linecolor:'rgba(255, 255, 255, 0.7)',
+      linewidth: 1
+    };
+
+    const layout = {
+      autosize: false,
+      width: 640,
+      height: 360,
+      title: 'Questions Asked Per Day',
+      font: { color: 'white' },
+      margin: { pad: 20 },
+      xaxis: axisStyle,
+      yaxis: axisStyle,
+      paper_bgcolor: 'rgba(0, 0, 0, 0)',
+      plot_bgcolor: 'rgba(0, 0, 0, 0)'
+    };
+
+    const options = {
+      fileopt: 'overwrite',
+      filename: 'magic-8ball-questions',
+      layout: layout
+    };
+
+    Plotly.plot(data, options, function(err, msg) {
+      if (err) console.log(err);
+    });
+
+    console.log('Plotly: loaded questions graph');
+  }
+
+  updateRatiosGraph()
+  {
+    const data = [{
+      labels: [ 'affirmative', 'non-committal', 'negative' ],
+      values: [ 6, 7, 4 ],
+      marker: { colors: [ '#63DA62', '#D9DA62', '#DA4D4D' ] },
+      type: 'pie',
+    }];
+
+    const layout = {
+      autosize: false,
+      width: 640,
+      height: 360,
+      title: 'Answer Type Ratios',
+      font: { color: 'white' },
+      margin: { pad: 20 },
+      paper_bgcolor: 'rgba(0, 0, 0, 0)',
+      plot_bgcolor: 'rgba(0, 0, 0, 0)'
+    }
+
+    const options = {
+      fileopt: 'overwrite',
+      filename: 'magic-8ball-ratios',
+      layout: layout
+    };
+
+    Plotly.plot(data, options, function(err, msg) {
+      if (err) console.log(err);
+    });
+
+    console.log('Plotly: loaded ratios pie chart');
+  }
+
   render()
   {
+    const questionsGraph = {
+      url: 'https://plot.ly/~ChrisMB/2',
+      key: 'tUBvWHACIGKG6w8PZXtlQD',
+      alt: 'Magic 8-Ball Questions',
+      id: 2
+    }
+    this.updateQuestionsGraph();
+
+    const ratiosGraph = {
+      url: 'https://plot.ly/~ChrisMB/6',
+      key: 'rXv3RRBQPtWKvn0njhpM7d',
+      alt: 'Magic 8-Ball Ratios',
+      id: 6
+    }
+    this.updateRatiosGraph();
+
     return (
-      <PageLayout appName={ this.props.appName } title="Statistics">
-        <div>{ this.props.appName } Statistics</div>
+      <PageLayout title="Statistics">
+        <div className="stats">
+          <Graph graph={ questionsGraph } />
+          <Graph graph={ ratiosGraph } />
+        </div>
       </PageLayout>
+    );
+  }
+}
+
+// Plotly Graph
+class Graph extends React.Component
+{
+  render()
+  {
+    const graph = this.props.graph;
+
+    const style = {
+      display: 'block',
+      textAlign: 'center'
+    };
+
+    return(
+      <div>
+        <a href={ graph.url + '/?share_key=' + graph.key } target="_blank" title={ graph.alt } styles={ style }>
+          <img src={ graph.url + '.png?share_key=' + graph.key } alt={ graph.alt } onerror="this.onerror=null;this.src='https://plot.ly/404.png';" />
+        </a>
+        <script data-plotly={ 'ChrisMB:' + graph.id } sharekey-plotly={ graph.key } src="https://plot.ly/embed.js" async />
+      </div>
     );
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2007,6 +2007,14 @@
         "find-up": "^2.1.0"
       }
     },
+    "plotly": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/plotly/-/plotly-1.0.6.tgz",
+      "integrity": "sha1-smcsPfiDM2Jb32hJgtDj9lIdeqo=",
+      "requires": {
+        "mkdirp": "~0.5.0"
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "express": "^4.16.4",
     "express-react-views": "^0.11.0",
     "less-middleware": "^3.1.0",
+    "plotly": "^1.0.6",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "sequelize": "^4.43.0",


### PR DESCRIPTION
Implemented a graph tracking the amount of questions asked per day, as well as one breaking down the distribution of the different answer types.

This was done with the help of [plot.ly](https://plot.ly), setup using static dummy data during which I annoyingly ran out of free API calls. According to the error message, the lockout has a 24h cycle, but it has so far persisted over Sunday, so I've been unable to test the graphs with the live data from the database. Not ideal given that the deadline for this project is up, but fingers crossed! :crossed_fingers: